### PR TITLE
Add new rules to PHP 7.3+ ruleset.

### DIFF
--- a/DrupalExtended73/ruleset.xml
+++ b/DrupalExtended73/ruleset.xml
@@ -62,6 +62,7 @@
   <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
   <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
   <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
+  <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
   <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
   <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>
   <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>

--- a/DrupalExtended73/ruleset.xml
+++ b/DrupalExtended73/ruleset.xml
@@ -15,6 +15,7 @@
   <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
   <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
   <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+  <rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>
   <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
   <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
   <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
@@ -26,14 +27,18 @@
       <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true"/>
     </properties>
   </rule>
+  <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+  <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
+  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>
   <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
   <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
   <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
   <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction"/>
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
   <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
-  <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
   <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
   <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
   <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
   <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
@@ -49,6 +54,7 @@
     </properties>
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
   <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
   <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
   <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
@@ -58,4 +64,6 @@
   <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
   <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
   <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>
+  <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+  <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
 </ruleset>


### PR DESCRIPTION
Added new rules for PHP 7.3+ ruleset:

- `SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable` utility rule
- `SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable` it's a bad practice anyway
- `SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators` utility rule that ask to replace `$foo = $foo + 1;` by `$foo++`.
- `SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile` can't see why in Drupal codebase two namespaces are needed, most likely it will confuse Drupal. Can be handy in some edge-cases.
- `SlevomatCodingStandard.Namespaces.MultipleUsesPerLine` I don't think this is allowed by Drupal anyway.
- `SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly` utility rule
- `SlevomatCodingStandard.Exceptions.DeadCatch` utility rule