### PR TITLE
Add new rules to PHP 7.4+ ruleset.

### DIFF
--- a/DrupalExtended74/ruleset.xml
+++ b/DrupalExtended74/ruleset.xml
@@ -5,11 +5,15 @@
   <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
     <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
   </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
   <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
   <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction"/>
+  <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+  <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
   <rule ref="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator">
     <properties>
       <property name="minDigitsBeforeDecimalPoint" value="6"/>
     </properties>
   </rule>
+  <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
 </ruleset>


### PR DESCRIPTION
Added new rules for PHP 7.4+ ruleset:

- `SlevomatCodingStandard.Functions.RequireTrailingCommaInCall` required by Drupal as for array items, but not checked yet. Available since PHP 7.4 so put it here.
- `SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing` utility rule
- `SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking` utility rule for - https://youtu.be/dSjLTZMDUuw?t=912
- `SlevomatCodingStandard.Functions.ArrowFunctionDeclaration` makes sure that after `fn` there is a space, as well as before and after `=>`.