### PR TITLE
Add ruleset for PHP 8.0+.

### DIFF
--- a/DrupalExtended80/ruleset.xml
+++ b/DrupalExtended80/ruleset.xml
@@ -2,7 +2,12 @@
 <ruleset name="DrupalExtended">
   <description>An extension of Drupal coding standards (PHP 8.0+).</description>
   <rule ref="../DrupalExtended74"/>
-  <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+    <properties>
+      <property name="shortNullable" value="yes"/>
+      <property name="withSpaces" value="no"/>
+    </properties>
+  </rule>
   <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
   <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
   <rule ref="SlevomatCodingStandard.Functions.RequireSingleLineCall">

--- a/DrupalExtended80/ruleset.xml
+++ b/DrupalExtended80/ruleset.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset name="DrupalExtended">
+  <description>An extension of Drupal coding standards (PHP 8.0+).</description>
+  <rule ref="../DrupalExtended74"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
+  <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+  <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+  <rule ref="SlevomatCodingStandard.Functions.RequireSingleLineCall">
+    <properties>
+      <property name="maxLineLength" value="80"/>
+    </properties>
+  </rule>
+  <rule ref="SlevomatCodingStandard.Functions.RequireMultiLineCall">
+    <properties>
+      <property name="minLineLength" value="80"/>
+    </properties>
+  </rule>
+  <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
+  <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator"/>
+</ruleset>


### PR DESCRIPTION
Added new ruleset for PHP 8.0+ with new rules specifically for that version and up:

- `SlevomatCodingStandard.TypeHints.UnionTypeHintFormat` configured to
  - Always force declare short nullable like `?Foo` instead of `null|Foo`
  - Requires no spaces between types. Valid `foo|bar`, invalid `foo | bar`. This make it consistent with a doc block type declaration in Drupal.
- `SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration` requires comma for last parameter in function declaration (Drupal requires it as per arrays but not checking yet as far as I'm aware).
- `SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse` make it consisted with functions and array to have last element with a comma
- (not sure) `SlevomatCodingStandard.Functions.RequireSingleLineCall` this will force calling function in a single line if it's not exceed 80 chars (Drupal max chars per line).
- (not sure) `SlevomatCodingStandard.Functions.RequireMultiLineCall` this will force calling a function with parameters passed in multiple lines if it exceeds 80 chars or chop chained calls.
- `SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch` if exception variable is not used, simply ask for removing it and leave only exception type.
- `SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator` seems helpful, but actually wasn't able to find out any suggestion in my codebase at this point. Maybe it's unsafe to enable it right now.