### PR TITLE
Add ruleset for PHP 8.1+.

### DIFF
--- a/DrupalExtended81/ruleset.xml
+++ b/DrupalExtended81/ruleset.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="DrupalExtended">
+  <description>An extension of Drupal coding standards (PHP 8.1+).</description>
+  <rule ref="../DrupalExtended80"/>
+  <!-- No specific rules for PHP 8.1+ yet. -->
+</ruleset>


### PR DESCRIPTION
Adds ruleset for PHP 8.1.

For consistency and more convenient usage, I think it's better to have this file even without rules. Because, it can be confusing seeing ruleset for 8.0 on a project with PHP 8.1+, trying to update rules to 81 will break checks.

Requires #3 to be merged first.